### PR TITLE
Add latest letsencrypt agreement to response file

### DIFF
--- a/templates/response-file.yml.j2
+++ b/templates/response-file.yml.j2
@@ -9,6 +9,7 @@
 # This file is YAML. Note that JSON is a subset of YAML.
 "acme-enter-email": {{ acmetool_responses_email }}
 "acme-agreement:https://letsencrypt.org/documents/LE-SA-v1.0.1-July-27-2015.pdf": true
+"acme-agreement:https://letsencrypt.org/documents/LE-SA-v1.1.1-August-1-2016.pdf": true
 "acmetool-quickstart-choose-server": https://acme-v01.api.letsencrypt.org/directory
 "acmetool-quickstart-choose-method": {{ acmetool_responses_method }}
 # This is only used if "acmetool-quickstart-choose-method" is "webroot".


### PR DESCRIPTION
Let's Encrypt updated their agreement - this adds the new agreement to the response file so things work without manual intervention to accept the new agreement. 