### PR TITLE
Only run the PPA task on Ubuntu boxes

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,7 @@
 - apt_repository:
     repo: "ppa:hlandau/rhea"
     update_cache: "yes"
+  when: ansible_distribution == "Ubuntu"
   tags: acmetool-install
 
 - apt:


### PR DESCRIPTION
I'm using this role on Debian machines rather than Ubuntu and ppa's don't work there. Debian testing ships acmetool in the default repo