### PR TITLE
Bionic support + minor flexibility improvements

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,15 +1,18 @@
 ---
 # defaults file for ansible-acmetool
 
-# TODO: webserver (apache or nginx)
+# web server (apache, nginx, none)
 acmetool_websrv: "nginx"
 
 # acmetool response file
+
+acmetool_responses_method: "webroot"  # this is overridden if acmetool_websrv is set
 acmetool_responses_email: "hostmaster@example.com"
 acmetool_responses_install_cronjob: "true"
 acmetool_responses_install_haproxy_script: "false"
 acmetool_responses_install_redirector_systemd: "false"
 acmetool_responses_agreement: "https://letsencrypt.org/documents/LE-SA-v1.2-November-15-2017.pdf"
+acmetool_responses_webroot_path: "/var/www/foo/bar/.well-known/acme-challenge"  # only when acmetool_responses_method == "webroot"
 
 # acmetool cert hostname
 # for multiple sites with one cert, separate site names with a space

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,7 @@
   apt_repository:
     repo: "ppa:hlandau/rhea"
     update_cache: "yes"
+    codename: xenial
   when: ansible_os_family == "Debian"
   tags: acmetool-install
 

--- a/tasks/nginx-stateless.yml
+++ b/tasks/nginx-stateless.yml
@@ -15,12 +15,14 @@
   template:
     src: "etc_nginx_sites_acmetool.conf.j2"
     dest: "/etc/nginx/sites-available/{{ acmetool_nginx_sites_filename }}"
+  when: acmetool_nginx_sites_filename != ""
 
 - name: "enable acmetool nginx temporary site"
   file:
     src: "/etc/nginx/sites-available/{{ acmetool_nginx_sites_filename }}"
     dest: "/etc/nginx/sites-enabled/{{ acmetool_nginx_sites_filename }}"
     state: "link"
+  when: acmetool_nginx_sites_filename != ""
 
 - name: "reload nginx"
   service:

--- a/templates/response-file.yml.j2
+++ b/templates/response-file.yml.j2
@@ -12,7 +12,7 @@
 "acmetool-quickstart-choose-server": https://acme-v01.api.letsencrypt.org/directory
 "acmetool-quickstart-choose-method": {{ acmetool_responses_method }}
 # This is only used if "acmetool-quickstart-choose-method" is "webroot".
-"acmetool-quickstart-webroot-path": "/var/www/foo/bar/.well-known/acme-challenge"
+"acmetool-quickstart-webroot-path": {{ acmetool_responses_webroot_path }}
 "acmetool-quickstart-complete": true
 "acmetool-quickstart-install-cronjob": {{ acmetool_responses_install_cronjob }}
 "acmetool-quickstart-install-haproxy-script": {{ acmetool_responses_install_haproxy_script }}


### PR DESCRIPTION
# Ubuntu 18.04 (Bionic) support

Upstream hasn't published the PPA repo for Bionic (hlandau/acme#307), so acquiring it fails on Bionic. However, quoting the readme:

> (Note: There is no difference between the .deb files for different Ubuntu release codenames; they are interchangeable and completely equivalent.)

This means it should be safe to always use Xenial.

# Nginx assumptions lessened

Not all nginx installations (e.g. those installed with https://github.com/nginxinc/ansible-role-nginx) have a `sites-available`/`sites-enabled` directory, so if the `acmetool_nginx_sites_filename` variable is emptied, no files are attempted to be written there.

# First-class support for webroot

Webroot is now a more first-class supported method, as the path variable is exposed and can thus be used in a custom (no-magic) nginx config.