### PR TITLE
Add variable to make ACME server URL configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,6 @@
 acmetool_websrv: "nginx"
 
 # acmetool response file
-
 acmetool_responses_method: "webroot"  # this is overridden if acmetool_websrv is set
 acmetool_responses_email: "hostmaster@example.com"
 acmetool_responses_install_cronjob: "true"
@@ -13,6 +12,9 @@ acmetool_responses_install_haproxy_script: "false"
 acmetool_responses_install_redirector_systemd: "false"
 acmetool_responses_agreement: "https://letsencrypt.org/documents/LE-SA-v1.2-November-15-2017.pdf"
 acmetool_responses_webroot_path: "/var/www/foo/bar/.well-known/acme-challenge"  # only when acmetool_responses_method == "webroot"
+acmetool_responses_server: "https://acme-v01.api.letsencrypt.org/directory" # Let's Encrypt production
+#    to use Let's Encrypt staging environment, replace above with
+#    acmetool_responses_server: "https://acme-staging.api.letsencrypt.org/directory"
 
 # acmetool cert hostname
 # for multiple sites with one cert, separate site names with a space

--- a/templates/response-file.yml.j2
+++ b/templates/response-file.yml.j2
@@ -9,7 +9,7 @@
 # This file is YAML. Note that JSON is a subset of YAML.
 "acme-enter-email": {{ acmetool_responses_email }}
 "acme-agreement:{{ acmetool_responses_agreement }}": true
-"acmetool-quickstart-choose-server": https://acme-v01.api.letsencrypt.org/directory
+"acmetool-quickstart-choose-server": {{ acmetool_responses_server }}
 "acmetool-quickstart-choose-method": {{ acmetool_responses_method }}
 # This is only used if "acmetool-quickstart-choose-method" is "webroot".
 "acmetool-quickstart-webroot-path": {{ acmetool_responses_webroot_path }}


### PR DESCRIPTION
Add acmetool_responses_server variable. This allows to choose between
Let's Encrypt prod or staging environments.