### PR TITLE
Use artefactual repositories for packages

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,12 +1,32 @@
 ---
 # tasks file for ansible-acmetool
 
-- name: Add Ubuntu repo
+- name: Add Artefactual repo key (Ubuntu)
+  apt_key:
+    url: "https://packages.archivematica.org/acmetool/key.asc"
+    state: present
+  when:
+    - ansible_os_family == "Debian"
+    - ansible_distribution_version is version('18.04', '<=')
+  tags: acmetool-install
+
+- name: Add Ubuntu repo (version <= 16.04)
   apt_repository:
-    repo: "ppa:hlandau/rhea"
+    repo: "deb [arch=amd64] http://packages.archivematica.org/acmetool/ubuntu xenial main"
     update_cache: "yes"
-    codename: xenial
-  when: ansible_os_family == "Debian"
+  when:
+    - ansible_os_family == "Debian"
+    - ansible_distribution_version is version('16.04', '<=')
+  tags: acmetool-install
+
+# Ubuntu focal (20.04) includes acmetool in official repositories
+- name: Add Ubuntu repo (version = 18.04)
+  apt_repository:
+    repo: "deb [arch=amd64] http://packages.archivematica.org/acmetool/ubuntu bionic main"
+    update_cache: "yes"
+  when:
+    - ansible_os_family == "Debian"
+    - ansible_distribution_version is version('18.04', '==')
   tags: acmetool-install
 
 - name: Install acmetool package (Ubuntu)
@@ -19,7 +39,7 @@
 - name: Add RedHat/CentOS repo file
   template:
     src: "acmetool_centos7.repo.j2"
-    dest: "/etc/yum.repos.d/acmetool.repo"
+    dest: "/etc/yum.repos.d/artefactual-acmetool.repo"
     owner: "root"
     group: "root"
     mode: "0644"

--- a/templates/acmetool_centos7.repo.j2
+++ b/templates/acmetool_centos7.repo.j2
@@ -1,11 +1,6 @@
-#https://copr.fedorainfracloud.org/coprs/hlandau/acmetool/repo/epel-7/hlandau-acmetool-epel-7.repo
-[hlandau-acmetool]
-name=Copr repo for acmetool owned by hlandau
-baseurl=https://copr-be.cloud.fedoraproject.org/results/hlandau/acmetool/epel-7-$basearch/
-type=rpm-md
-skip_if_unavailable=True
+[acmetool-artefactual-repo]
+name=acmetool-artefactual-repo
+baseurl=https://packages.archivematica.org/acmetool/centos
 gpgcheck=1
-gpgkey=https://copr-be.cloud.fedoraproject.org/results/hlandau/acmetool/pubkey.gpg
-repo_gpgcheck=0
+gpgkey=https://packages.archivematica.org/acmetool/key.asc
 enabled=1
-enabled_metadata=1


### PR DESCRIPTION
The old repos have not been updated to use acmetool v0.2.1. The v0.2.1 packages
have been created with am-packbuild and published in artefactual package
repositories:

https://packages.archivematica.org/acmetool/ubuntu/
https://packages.archivematica.org/acmetool/centos/

Connects to #17 