### PR TITLE
Put temporary nginx server config in  /etc/nginx/conf.d/

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This will get a cert valid for www.example.com and example.com and another cert 
 Notes for nginx stateless mode:
 ------------------------------
 
-1) This role will add and temporarily enable configuration for a site to get the initial LE certificate (the site is disabled by the role after getting the certs, the configuration file is kept for reference in the directory `/etc/nginx/sites-available/`)
+1) This role will add and temporarily enable configuration for a site to get the initial LE certificate (the site is disabled by the role after getting the certs, the configuration file is kept (disabled) for reference in the directory `/etc/nginx/conf.d/`)
 
 2) The role creates file `/etc/nginx/acmetool-location.conf`, with configuration for a stateless ACME challenge location. Include this file in your site configuration, inside the server block along the other location definitions, in order for automated cert renewal to work, for example like this:
 

--- a/tasks/nginx-stateless-disable-temp-site.yml
+++ b/tasks/nginx-stateless-disable-temp-site.yml
@@ -1,10 +1,17 @@
 ---
 
 - name: "disable acmetool nginx temporary site"
-  file:
-    name: "/etc/nginx/sites-enabled/{{ acmetool_nginx_sites_filename }}"
-    state: "absent"
+  command:
+    cmd: "mv -f {{ acmetool_nginx_sites_filename }} {{ acmetool_nginx_sites_filename }}.org"
+    chdir: "/etc/nginx/conf.d"
+    removes: "{{ acmetool_nginx_sites_filename }}"
+
+- name: "reload nginx"
+  service:
+    name: "nginx"
+    state: "reloaded"
 
 - name: "Remind user to update their site config"
   debug:
     msg: "Please add 'include /etc/nginx/acmetool-location.conf;' in your nginx site configuration for future cert renewal to work"
+

--- a/tasks/nginx-stateless.yml
+++ b/tasks/nginx-stateless.yml
@@ -15,19 +15,10 @@
     src: "etc_nginx_acmetool-location.conf.j2"
     dest: "/etc/nginx/acmetool-location.conf"
 
-- name: "template acmetool nginx temporary site"
+- name: Add configuration for nginx temporary site from template
   template:
     src: "etc_nginx_sites_acmetool.conf.j2"
-    dest: "/etc/nginx/sites-available/{{ acmetool_nginx_sites_filename }}"
-  when:
-    - acmetool_nginx_sites_filename != ""
-    - acmetool_want is defined
-
-- name: "enable acmetool nginx temporary site"
-  file:
-    src: "/etc/nginx/sites-available/{{ acmetool_nginx_sites_filename }}"
-    dest: "/etc/nginx/sites-enabled/{{ acmetool_nginx_sites_filename }}"
-    state: "link"
+    dest: "/etc/nginx/conf.d/{{ acmetool_nginx_sites_filename }}"
   when:
     - acmetool_nginx_sites_filename != ""
     - acmetool_want is defined


### PR DESCRIPTION
Put the temporary nginx server config in /etc/nginx/conf.d instead
of /etc/nginx/sites-available|enabled, as not all nginx installations
use these directories