### PR TITLE
Fix nginx stateless mode temp config 

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This will get a cert valid for www.example.com and example.com and another cert 
 Notes for nginx stateless mode:
 ------------------------------
 
-1) This role will add and temporarily enable configuration for a site to get the initial LE certificate (the site is disabled by the role after getting the certs, the configuration file is kept for reference in the directory `/etc/nginx/sites-available/`)
+1) This role will add and temporarily enable configuration for a site to get the initial LE certificate (the site is disabled by the role after getting the certs, the configuration file is kept (disabled) for reference in the directory `/etc/nginx/conf.d/`)
 
 2) The role creates file `/etc/nginx/acmetool-location.conf`, with configuration for a stateless ACME challenge location. Include this file in your site configuration, inside the server block along the other location definitions, in order for automated cert renewal to work, for example like this:
 

--- a/tasks/nginx-stateless-disable-temp-site.yml
+++ b/tasks/nginx-stateless-disable-temp-site.yml
@@ -1,10 +1,17 @@
 ---
 
 - name: "disable acmetool nginx temporary site"
-  file:
-    name: "/etc/nginx/sites-enabled/{{ acmetool_nginx_sites_filename }}"
-    state: "absent"
+  command:
+    cmd: "mv -f {{ acmetool_nginx_sites_filename }} {{ acmetool_nginx_sites_filename }}.org"
+    chdir: "/etc/nginx/conf.d"
+    removes: "{{ acmetool_nginx_sites_filename }}"
+
+- name: "reload nginx"
+  service:
+    name: "nginx"
+    state: "reloaded"
 
 - name: "Remind user to update their site config"
   debug:
     msg: "Please add 'include /etc/nginx/acmetool-location.conf;' in your nginx site configuration for future cert renewal to work"
+

--- a/tasks/nginx-stateless.yml
+++ b/tasks/nginx-stateless.yml
@@ -15,19 +15,10 @@
     src: "etc_nginx_acmetool-location.conf.j2"
     dest: "/etc/nginx/acmetool-location.conf"
 
-- name: "template acmetool nginx temporary site"
+- name: Add configuration for nginx temporary site from template
   template:
     src: "etc_nginx_sites_acmetool.conf.j2"
-    dest: "/etc/nginx/sites-available/{{ acmetool_nginx_sites_filename }}"
-  when:
-    - acmetool_nginx_sites_filename != ""
-    - acmetool_want is defined
-
-- name: "enable acmetool nginx temporary site"
-  file:
-    src: "/etc/nginx/sites-available/{{ acmetool_nginx_sites_filename }}"
-    dest: "/etc/nginx/sites-enabled/{{ acmetool_nginx_sites_filename }}"
-    state: "link"
+    dest: "/etc/nginx/conf.d/{{ acmetool_nginx_sites_filename }}"
   when:
     - acmetool_nginx_sites_filename != ""
     - acmetool_want is defined

--- a/tasks/nginx-stateless.yml
+++ b/tasks/nginx-stateless.yml
@@ -16,9 +16,18 @@
     dest: "/etc/nginx/acmetool-location.conf"
 
 - name: Add configuration for nginx temporary site from template
-  template:
-    src: "etc_nginx_sites_acmetool.conf.j2"
-    dest: "/etc/nginx/conf.d/{{ acmetool_nginx_sites_filename }}"
+  block:
+    # (initially tried to use a plain {{ acmetool_want|join(' ') }} to make the 
+    # nginx config's server_name, but it didn't work when acmetool_want 
+    # is a single string)
+    - set_fact:
+        fact_nginx_server_name: ""
+    - set_fact:
+        fact_nginx_server_name: "{{ fact_nginx_server_name }} {{ item }}"
+      with_items: "{{ acmetool_want }}"
+    - template:
+        src: "etc_nginx_sites_acmetool.conf.j2"
+        dest: "/etc/nginx/conf.d/{{ acmetool_nginx_sites_filename }}"
   when:
     - acmetool_nginx_sites_filename != ""
     - acmetool_want is defined

--- a/templates/etc_nginx_sites_acmetool.conf.j2
+++ b/templates/etc_nginx_sites_acmetool.conf.j2
@@ -4,23 +4,20 @@
 # will be enabled momentarily to get certs and then disabled
 
 server {
-	listen 80 default_server;
-	# commenting out the line below due to errors on systems without IPv6 support
-	#listen [::]:80 default_server ipv6only=on;
+    listen 80;
 
-	root /usr/share/nginx/html;
-	index index.html index.htm;
+    root /usr/share/nginx/html;
+    index index.html index.htm;
 
-	# Make site accessible from http://localhost/
-	server_name localhost;
+    server_name {{ fact_nginx_server_name }};
 
     include /etc/nginx/acmetool-location.conf;    
 
-	location / {
-		# First attempt to serve request as file, then
-		# as directory, then fall back to displaying a 404.
-		try_files $uri $uri/ =404;
-	}
+    location / {
+        # First attempt to serve request as file, then
+        # as directory, then fall back to displaying a 404.
+        try_files $uri $uri/ =404;
+    }
 
 }
 


### PR DESCRIPTION
Fix nginx temporary config to prevent acmetool want failures when
there is a default server already configured

Fixes https://github.com/artefactual-labs/ansible-acmetool/issues/21