### PR TITLE
Update url to subscriber agreement in response file

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,7 +11,7 @@ acmetool_responses_email: "hostmaster@example.com"
 acmetool_responses_install_cronjob: "true"
 acmetool_responses_install_haproxy_script: "false"
 acmetool_responses_install_redirector_systemd: "false"
-acmetool_responses_agreement: "https://letsencrypt.org/documents/LE-SA-v1.2-November-15-2017.pdf"
+acmetool_responses_agreement: "https://letsencrypt.org/documents/LE-SA-v1.3-September-21-2022.pdf"
 acmetool_responses_webroot_path: "/var/www/foo/bar/.well-known/acme-challenge"  # only when acmetool_responses_method == "webroot"
 
 # acmetool cert hostname


### PR DESCRIPTION
There is a new version of the LE subscriber agreement (v1.3), the url needs to be updated so that acmetool quickstart does not stall (as it requires the user to manually agree the terms of service)

https://github.com/artefactual-labs/ansible-acmetool/issues/24