### PR TITLE
Stop using deprecated `include` module in tasks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -106,12 +106,12 @@
 
 
 - name: "apache specific config tasks"
-  include: "apache-proxy.yml"
+  import_tasks: "apache-proxy.yml"
   when: acmetool_websrv == "apache"
   tags: acmetool-websrv
 
 - name: "nginx specific config tasks"
-  include: "nginx-stateless.yml"
+  import_tasks: "nginx-stateless.yml"
   when: acmetool_websrv == "nginx"
   tags: acmetool-websrv
 
@@ -122,7 +122,7 @@
   when: acmetool_want is defined
 
 - name: "nginx specific config tasks after getting certs"
-  include: "nginx-stateless-disable-temp-site.yml"
+  import_tasks: "nginx-stateless-disable-temp-site.yml"
   tags: acmetool-websrv
   when:
    - acmetool_want is defined


### PR DESCRIPTION
The `include` module will not work anymore in ansible 2.16 and was set as deprecated in ansible 2.4 (at least).